### PR TITLE
Letsencrypt improvements

### DIFF
--- a/bare/roles/web/tasks/letsencrypt.yml
+++ b/bare/roles/web/tasks/letsencrypt.yml
@@ -19,7 +19,11 @@
   command: "systemctl reload nginx"
 
 - name: Install letsencrypt cert
-  command: letsencrypt certonly -n --webroot -d {{ mastodon_host }} -w {{ mastodon_home }}/{{ mastodon_path }}/public/ --email "webmaster@{{ mastodon_host }}" --agree-tos && systemctl reload nginx
+  command: letsencrypt certonly -n --webroot -d {{ mastodon_host }} -w {{ mastodon_home }}/{{ mastodon_path }}/public/ --email "webmaster@{{ mastodon_host }}" --agree-tos
+  when: not letsencrypt_cert.stat.exists
+
+- name: Reload nginx
+  command: "systemctl reload nginx"
   when: not letsencrypt_cert.stat.exists
 
 - name: Letsencrypt Job

--- a/bare/roles/web/tasks/packages.yml
+++ b/bare/roles/web/tasks/packages.yml
@@ -9,6 +9,14 @@
     install_recommends: no
   with_items: "{{ packages }}"
 
+- name: Install letsencrypt certbot
+  package:
+    name: "certbot"
+  when: (
+    (ansible_distribution == "Debian" && ansible_distribution_major_version >= 9)
+    || (ansible_distribution == "Ubuntu" && ansible_distribution_release == 'eoan')
+    || (ansible_distribution == "Ubuntu" && ansible_distribution_release == 'focal'))
+
 - name: nodejs alternative
   alternatives:
     name: node

--- a/bare/vars/common.yml
+++ b/bare/vars/common.yml
@@ -1,6 +1,6 @@
-ruby_version: 2.6.5
+ruby_version: 2.6.6
 rbenv_version: v1.1.1
-ruby_build_version: v20191004
+ruby_build_version: v20200401
 os_family: "{{ ansible_os_family|lower }}"
 mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"

--- a/spec/debian/debian_spec.rb
+++ b/spec/debian/debian_spec.rb
@@ -20,7 +20,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby -v') do
-      its(:stdout) { should match(/2\.6\.5/) }
+      its(:stdout) { should match(/2\.6\.6/) }
     end
 
     describe file('/usr/bin/nodejs') do
@@ -71,7 +71,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby-build --version') do
-      its(:stdout) { should match(/ruby-build 20191004/) }
+      its(:stdout) { should match(/ruby-build 20200401/) }
     end
 
     describe file('/home/mastodon/live') do


### PR DESCRIPTION
Two commits:

The first one fixes the call to `letsencrypt certonly` which uses shell syntax with the command module in current master.

The second one installs certbot on (some) distributions where it's available, namely Debian Stretch and newer and Ubuntu 19.10 and 20.04. If there's a nice way to say Ubuntu >= 19.10, please let me know :)