### PR TITLE
Add missing certbot

### DIFF
--- a/bare/vars/debian_vars.yml
+++ b/bare/vars/debian_vars.yml
@@ -35,6 +35,7 @@ packages:
   - package: "unattended-upgrades"
   - package: "yarn"
   - package: "zlib1g-dev"
+  - package: "certbot"
 
 postgres:
   packages:


### PR DESCRIPTION
Looks like `certbot` package is missing on Debian, causing whole installation to fail with 
```
 FAILED! => {"changed": false, "cmd": "letsencrypt certonly -n --webroot -d mastodon.scoiatael.dev -w /home/mastodon/live/public/ --email '' --agree-tos", "msg": "[Errno 2] No such file or directory", "rc": 2}
```