### PR TITLE
Fix for Mastodon 500ing on media upload due of incorrect file permissions

### DIFF
--- a/bare/roles/web/tasks/nginx.yml
+++ b/bare/roles/web/tasks/nginx.yml
@@ -148,6 +148,28 @@
     - ansible_os_family == "RedHat"
     - mastodon_host is defined
 
+- name: "Ensure that we have correct file permissions for /var/lib/nginx/ as we are not running NGINX under default user"
+  become: yes
+  become_user: root
+  file:
+    path: "/var/lib/nginx/"
+    owner: "{{ mastodon_user }}"
+    group: "nginx"
+    recurse: yes
+  when:
+    - ansible_os_family == "RedHat"
+
+- name: "Ensure that we have correct file permissions for /var/lib/nginx/ as we are not running NGINX under default user"
+  become: yes
+  become_user: root
+  file:
+    path: "/var/lib/nginx/"
+    owner: "{{ mastodon_user }}"
+    group: "www-data"
+    recurse: yes
+  when:
+    - ansible_os_family == "Debian"
+
 - name: Restart nginx
   become: yes
   #Workaround for "Interactive authentication required" issue


### PR DESCRIPTION
Turns out that file uploads are being handled by NGINX, and because we are running NGINX under a non-default user due of avoiding permission issues for the files in home folder, `/var/lib/nginx/` now has incorrect permissions and gets missed completely in testing until you have full instance deployed and try to upload media and causes 500.

Just fixing permissions for `/var/lib/nginx/` to allow nginx to write files into `/var/lib/nginx/tmp/` fixes the 500 issue 