### PR TITLE
Update default Ruby version to 3.0.4

### DIFF
--- a/bare/vars/common.yml
+++ b/bare/vars/common.yml
@@ -1,5 +1,5 @@
-#rbenv: version `3.0.3' is not installed (set by /home/mastodon/live/.ruby-version)
-ruby_version: "3.0.3"
+#rbenv: version `3.0.4' is not installed (set by /home/mastodon/live/.ruby-version)
+ruby_version: "3.0.4"
 rbenv_version: "v1.2.0"
 ruby_build_version: "v20220426"
 bundler_version: "2.1.4"

--- a/goss.yaml
+++ b/goss.yaml
@@ -59,7 +59,7 @@ command:
     exit-status: 0
     exec: "sudo -u mastodon -i ruby -v"
     stdout:
-      - "3.0.3"
+      - "3.0.4"
   crontab:
     exit-status: 0
     exec: "sudo crontab -l -u mastodon"


### PR DESCRIPTION
This is the version Mastodon uses as of https://github.com/mastodon/mastodon/pull/18028