### PR TITLE
Pull only stable tag releases of Mastodon and not release candidates

### DIFF
--- a/bare/roles/web/tasks/mastodon.yml
+++ b/bare/roles/web/tasks/mastodon.yml
@@ -1,5 +1,5 @@
 - name: Fetch latest Mastodon version number
-  shell: "git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/mastodon/mastodon.git | tail --lines=1 | cut --delimiter='/' --fields=3"
+  shell: "git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/mastodon/mastodon.git | grep -v "rc" | tail --lines=1 | cut --delimiter='/' --fields=3"
   register: latest_mastodon_tag
 
 - name: Clone Mastodon

--- a/bare/roles/web/tasks/mastodon.yml
+++ b/bare/roles/web/tasks/mastodon.yml
@@ -1,5 +1,5 @@
 - name: Fetch latest Mastodon version number
-  shell: "git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/mastodon/mastodon.git | grep -v "rc" | tail --lines=1 | cut --delimiter='/' --fields=3"
+  shell: "git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/mastodon/mastodon.git | grep -v 'rc' | tail --lines=1 | cut --delimiter='/' --fields=3"
   register: latest_mastodon_tag
 
 - name: Clone Mastodon


### PR DESCRIPTION
I have noticed that when pulling the latest tag version from git, we're also allowing release candidates to be pulled and not just stable releases.

As Ruby 3 prioritizes backward-compatibility for all of its changes, this commit where default Ruby version is bumped to 3.0.4 should still work fine (Since we're reverting back to v3.5.3 from v4.0.0rc2):
https://github.com/mastodon/mastodon-ansible/commit/b9501f988c0c479947121b37fa1e9a2b4ed1e728

With `grep -v "rc"` we exclude any release candidate from the tags

Before:
```
thunderysteak@STEAK-DESKTOP:~> git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/mastodon/mastodon.git | tail --lines=1 | cut --delimiter='/' --fields=3
v4.0.0rc2
```

After:
```
thunderysteak@STEAK-DESKTOP:~> git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/mastodon/mastodon.git | grep -v "rc" | tail --lines=1 | cut --delimiter='/' --fields=3
v3.5.3
```

