### PR TITLE
Git client security fix for preflight, additional Goss test to verify that Mastodon deployed succesfully and that the Web UI is accessible and final Jammy fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,5 @@
 goss_version = '0.3.16'
 install_goss = <<~SHELL
-  echo "Giving NGINX a minute to restart before running tests" 
-  sleep 60
   echo "Running Goss tests:"
   echo "The target is \$TARGET" && \
   curl -Lo /tmp/goss https://github.com/aelsabbahy/goss/releases/download/v#{goss_version}/goss-linux-amd64 && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,7 @@
 goss_version = '0.3.16'
 install_goss = <<~SHELL
+  echo "Giving NGINX a minute to restart before running tests" 
+  sleep 60
   echo "Running Goss tests:"
   echo "The target is \$TARGET" && \
   curl -Lo /tmp/goss https://github.com/aelsabbahy/goss/releases/download/v#{goss_version}/goss-linux-amd64 && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,16 +70,19 @@ Vagrant.configure('2') do |config|
       #MacOS Ventura workaround
       #bare.vm.network :private_network, type: 'dhcp', name: "HostOnly", virtualbox__intnet: true
       bare.vm.network 'private_network', type: 'dhcp'
+
+      #Needs to be ran before running the playbook or Ansible checks will fail
+      #as we are checking against non-valid FQDN
+      bare.vm.provision 'shell' do |shell|
+        shell.privileged = true
+        shell.inline = localhost_domain
+      end
+
       bare.vm.provision 'ansible_local' do |ansible|
         ansible.playbook = 'bare/playbook.yml'
         ansible.extra_vars = ansible_extra_vars
         ansible.verbose = true
         ansible.skip_tags = 'letsencrypt'
-      end
-
-      bare.vm.provision 'shell' do |shell|
-        shell.privileged = true
-        shell.inline = localhost_domain
       end
 
       bare.vm.provision 'shell' do |shell|
@@ -94,7 +97,17 @@ Vagrant.configure('2') do |config|
 
   config.vm.define 'rhel8', autostart: false do |bare|
     bare.vm.box = 'geerlingguy/rockylinux8'
-    bare.vm.network 'private_network', type: 'dhcp'
+      #MacOS Ventura workaround
+      #bare.vm.network :private_network, type: 'dhcp', name: "HostOnly", virtualbox__intnet: true
+      bare.vm.network 'private_network', type: 'dhcp'
+
+    #Needs to be ran before running the playbook or Ansible checks will fail
+    #as we are checking against non-valid FQDN
+    bare.vm.provision 'shell' do |shell|
+      shell.privileged = true
+      shell.inline = localhost_domain
+    end
+
     bare.vm.provision 'ansible_local' do |ansible|
       ansible.playbook = 'bare/playbook.yml'
       ansible.extra_vars = ansible_extra_vars
@@ -106,11 +119,6 @@ Vagrant.configure('2') do |config|
     bare.vm.provision 'shell' do |shell|
       shell.privileged = true
       shell.inline = postgres_use_md5 
-    end
-
-    bare.vm.provision 'shell' do |shell|
-      shell.privileged = true
-      shell.inline = localhost_domain
     end
 
     bare.vm.provision 'shell' do |shell|
@@ -129,6 +137,14 @@ Vagrant.configure('2') do |config|
     #this error to be displayed "`playbook` does not exist on the guest: /vagrant/bare/playbook.yml error"
     #The generic image might be a just a little bit broken, but rockylinux/9 is not ready yet
     bare.vm.synced_folder ".", "/vagrant"
+
+    #Needs to be ran before running the playbook or Ansible checks will fail
+    #as we are checking against non-valid FQDN
+    bare.vm.provision 'shell' do |shell|
+      shell.privileged = true
+      shell.inline = localhost_domain
+    end
+
     bare.vm.provision 'ansible_local' do |ansible|
       ansible.playbook = 'bare/playbook.yml'
       ansible.extra_vars = ansible_extra_vars
@@ -140,11 +156,6 @@ Vagrant.configure('2') do |config|
     bare.vm.provision 'shell' do |shell|
       shell.privileged = true
       shell.inline = postgres_use_md5 
-    end
-
-    bare.vm.provision 'shell' do |shell|
-      shell.privileged = true
-      shell.inline = localhost_domain
     end
 
     bare.vm.provision 'shell' do |shell|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,9 +20,12 @@ sudo sed -i 's/host\s\s\s\sall\s\s\s\s\s\s\s\s\s\s\s\s\sall\s\s\s\s\s\s\s\s\s\s\
 sudo systemctl restart postgresql
 SHELL
 
+#Need to run this under root for it to stick and not throw permission errors
 localhost_domain = <<-'SHELL'
 echo "Set localhost to answer to mastodon.local"
+sudo su
 echo "127.0.0.1       mastodon.local" >> /etc/hosts
+exit
 SHELL
 
 ansible_extra_vars = {

--- a/bare/roles/preflight/tasks/preflight-checks.yml
+++ b/bare/roles/preflight/tasks/preflight-checks.yml
@@ -22,6 +22,8 @@
   - mastodon_install_exists.stat.exists
   - not mastodon_is_git.stat.exists
 
+#Have to run it under Mastodon user due of Git Security changes in newer OSes
+#https://github.blog/2022-04-12-git-security-vulnerability-announced/
 - name: Get local major version
   shell: "git tag --points-at HEAD | cut -c2-2"
   args:
@@ -29,8 +31,12 @@
   when:
     - mastodon_install_exists.stat.exists
     - mastodon_is_git.stat.exists
+  become: true
+  become_user: mastodon
   register: local_major_ver
 
+#Have to run it under Mastodon user due of Git Security changes in newer OSes
+#https://github.blog/2022-04-12-git-security-vulnerability-announced/
 - name: Get local minor version
   shell: "git tag --points-at HEAD | cut -c4-4"
   args:
@@ -39,6 +45,8 @@
     - mastodon_install_exists.stat.exists
     - mastodon_is_git.stat.exists
   register: local_minor_ver
+  become: true
+  become_user: mastodon
 
 - name: Fetch latest stable major Mastodon version number
   shell: "git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/mastodon/mastodon.git | grep -v 'rc' | tail --lines=1 | cut -d '/' -f 3 | cut -c2-2"

--- a/bare/roles/web/tasks/mastodon-postflight.yml
+++ b/bare/roles/web/tasks/mastodon-postflight.yml
@@ -131,22 +131,11 @@
   - ansible_os_family == "RedHat"
   - ansible_facts['distribution_major_version'] == "9"
 
-#https://github.com/microsoft/vscode/issues/136599#issuecomment-963074858
-#Running in blind, can't test this
-- name: Precompile assets with Legacy OpenSSL provider for Ubuntu Jammy
-  shell: "unset NODE_OPTIONS; NODE_OPTIONS=--openssl-legacy-provider RAILS_ENV=production ~/.rbenv/shims/bundle exec rails assets:precompile"
-  args:
-    chdir: "{{ mastodon_home }}/{{ mastodon_path }}"
-  when: 
-  - ansible_facts['distribution'] == 'Ubuntu'
-  - ansible_facts['distribution_release'] == 'jammy'
-
-
 - name: Precompile assets
   shell: "RAILS_ENV=production ~/.rbenv/shims/bundle exec rails assets:precompile"
   args:
     chdir: "{{ mastodon_home }}/{{ mastodon_path }}"
-  when: not (ansible_os_family == "RedHat" and ansible_facts['distribution_major_version'] == "9") or (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_release'] == 'jammy')
+  when: not ansible_os_family == "RedHat" and ansible_facts['distribution_major_version'] == "9"
 #We are installing new .env file, checking if .env file exists no longer required
 #  when: production_config.stat.exists
 

--- a/bare/roles/web/tasks/mastodon-postflight.yml
+++ b/bare/roles/web/tasks/mastodon-postflight.yml
@@ -135,7 +135,7 @@
   shell: "RAILS_ENV=production ~/.rbenv/shims/bundle exec rails assets:precompile"
   args:
     chdir: "{{ mastodon_home }}/{{ mastodon_path }}"
-  when: not ansible_os_family == "RedHat" and ansible_facts['distribution_major_version'] == "9"
+  when: not (ansible_os_family == "RedHat" and ansible_facts['distribution_major_version'] == "9")
 #We are installing new .env file, checking if .env file exists no longer required
 #  when: production_config.stat.exists
 

--- a/bare/roles/web/tasks/nginx.yml
+++ b/bare/roles/web/tasks/nginx.yml
@@ -177,3 +177,12 @@
   service: name=nginx state=restarted
   tags:
     - systemd
+
+- name: Check if Mastodon instance is up and running
+  uri:
+    url: 'https://{{ mastodon_host }}/about'
+    validate_certs: no
+  register: result
+  until: 'result.status == 200'
+  retries: 5
+  delay: 5

--- a/bare/roles/web/tasks/nginx.yml
+++ b/bare/roles/web/tasks/nginx.yml
@@ -177,3 +177,7 @@
   service: name=nginx state=restarted
   tags:
     - systemd
+
+- name: Wait for 1 minute for NGINX to start fully
+  pause:
+    minutes: 1

--- a/bare/roles/web/tasks/nginx.yml
+++ b/bare/roles/web/tasks/nginx.yml
@@ -177,7 +177,3 @@
   service: name=nginx state=restarted
   tags:
     - systemd
-
-- name: Wait for 1 minute for NGINX to start fully
-  pause:
-    minutes: 1

--- a/goss.yaml
+++ b/goss.yaml
@@ -81,6 +81,11 @@ command:
   postgres:
     exit-status: 0
     exec: "PGPASSWORD=CHANGEME psql -d mastodon_instance -h 127.0.0.1 -U mastodon -c 'CREATE TABLE test (v varchar(20)); DROP TABLE test;'"
+  #A Mastodon instance that is not running correctly will throw 500 and will not display the configured hostname
+  #Grepping for any mention of mastodon.local and returning status 0 if found is a good way to find out if the instance is running
+  curl:
+    exit-status: 0
+    exec: "curl -s --insecure https://mastodon.local/about | grep -q mastodon.local"
 
 user:
   mastodon:

--- a/goss.yaml
+++ b/goss.yaml
@@ -81,11 +81,13 @@ command:
   postgres:
     exit-status: 0
     exec: "PGPASSWORD=CHANGEME psql -d mastodon_instance -h 127.0.0.1 -U mastodon -c 'CREATE TABLE test (v varchar(20)); DROP TABLE test;'"
-  #A Mastodon instance that is not running correctly will throw 500 and will not display the configured hostname
-  #Grepping for any mention of mastodon.local and returning status 0 if found is a good way to find out if the instance is running
-  curl:
-    exit-status: 0
-    exec: "curl -s --insecure https://mastodon.local/about | grep -q mastodon.local"
+
+http:
+  https://mastodon.local/:
+    status: 200
+    allow-insecure: true
+    no-follow-redirects: false
+    body: [ mastodon.local ]
 
 user:
   mastodon:


### PR DESCRIPTION
Got more stuff:

- Fixed permission issue introduced by Git 2.35.2 Security Update: https://github.blog/2022-04-12-git-security-vulnerability-announced/ (Present currently only on Jammy)
- Created new Goss test that checks if we deployed the site correctly and is not 500ing
- Made localhost respond to mastodon.local

And the best thing for last:

- Finally got Ubuntu Jammy working (Ubuntu NodeJS defaults to OpenSSL 1.1.1 and we don't require the legacy OpenSSL flag)

```
==> jammy: Running provisioner: shell...
    jammy: Running: inline script
    jammy: Set localhost to answer to mastodon.local
==> jammy: Running provisioner: shell...
    jammy: Running: inline script
    jammy: Running Goss tests:
    jammy: The target is ubuntu
    jammy:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    jammy:                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 11.8M  100 11.8M    0     0   9.9M      0  0:00:01  0:00:01 --:--:-- 20.3M
    jammy: /tmp/goss: OK
    jammy: ..................................................................................
    jammy: 
    jammy: Total Duration: 0.520s
    jammy: Count: 82, Failed: 0, Skipped: 0
```
