### PR TITLE
Install all packages in one go

### DIFF
--- a/bare/roles/web/tasks/packages.yml
+++ b/bare/roles/web/tasks/packages.yml
@@ -8,13 +8,12 @@
 
 - name: Install packages
   package:
-    name: "{{ item.package }}"
+    name: "{{ packages | map(attribute='package') }}"
     update_cache: no
     #This makes the package module non-OS generic
     #https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html
     #    state: latest
     #    install_recommends: no
-  with_items: "{{ packages }}"
 
 #RHEL and Debian already has NodeJS in /usr/bin/node
 #Unclear what this is supposed to fix


### PR DESCRIPTION
This is considerably faster than looping over the list of packages, especially on latent ssh connections or slow servers.

It's the equivalent of doing `apt install package1 package2 package3`, instead of `apt install package1 && apt install package2 && apt install package3`