### PR TITLE
letsencrypt: Fix installation command

### DIFF
--- a/bare/roles/web/tasks/letsencrypt.yml
+++ b/bare/roles/web/tasks/letsencrypt.yml
@@ -19,7 +19,7 @@
   command: "systemctl reload nginx"
 
 - name: Install letsencrypt cert
-  command: letsencrypt certonly -n --webroot -d {{ mastodon_host }} -w {{ mastodon_home }}/{{ mastodon_path }}/public/ --email "webmaster@{{ mastodon_host }}" --agree-tos && systemctl reload nginx
+  command: letsencrypt certonly -n --webroot -d {{ mastodon_host }} -w {{ mastodon_home }}/{{ mastodon_path }}/public/ --email "webmaster@{{ mastodon_host }}" --agree-tos
   when: not letsencrypt_cert.stat.exists
 
 - name: Letsencrypt Job


### PR DESCRIPTION
You can't string two commands together like this with the `command` module, and we don't need to restart `nginx` here anyway because the configuration hasn't changed yet, and we don't need to serve anything with the new SSL certificates.